### PR TITLE
Update CGroups.ts

### DIFF
--- a/src/CGroups.ts
+++ b/src/CGroups.ts
@@ -44,7 +44,7 @@ export class CGroups {
           settingNames.map(name => {
             const value = setting[name];
             const filename = `${groupPath}/${resName}.${name}`;
-            return fs.writeFile(filename, value);
+            return fs.writeFile(filename, String(value));
           })
         );
       })


### PR DESCRIPTION
解决 Node 14.5.0 Linux 环境时，出现 `Data argument must be of type string/Buffer/TypedArray/DataView,` 的错误